### PR TITLE
Potential fix for code scanning alert no. 12: Missing CSRF middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@ var methodOverride = require('method-override');
 var logger = require('morgan');
 var errorHandler = require('errorhandler');
 var optional = require('optional');
+var lusca = require('lusca');
 var marked = require('marked');
 var fileUpload = require('express-fileupload');
 var dust = require('dustjs-linkedin');
@@ -46,6 +47,7 @@ app.use(session({
 }))
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
+app.use(lusca.csrf());
 app.use(fileUpload());
 
 // Routes

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "stream-buffers": "^3.0.1",
     "tap": "^11.1.3",
     "typeorm": "^0.2.24",
-    "validator": "^13.5.2"
+    "validator": "^13.5.2",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "browserify": "^13.1.1",


### PR DESCRIPTION
Potential fix for [https://github.com/snyk-labs/tmp-nodejs-goof/security/code-scanning/12](https://github.com/snyk-labs/tmp-nodejs-goof/security/code-scanning/12)

To fix the problem, we need to add CSRF protection middleware to the Express application. The `lusca` package provides CSRF protection and can be easily integrated into the existing code. We will install the `lusca` package and use its CSRF middleware in the Express app.

1. Install the `lusca` package.
2. Import the `lusca` package in the `app.js` file.
3. Add the CSRF middleware to the Express app configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
